### PR TITLE
Add modular audiobook and illustration pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+config.py
+outputs/
+
+__pycache__/

--- a/image_generation.py
+++ b/image_generation.py
@@ -1,0 +1,32 @@
+"""Generate an illustration per block using the OpenAI API."""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Dict, List
+
+from openai import OpenAI
+
+import config
+from utils import ensure_dir, slugify
+
+
+def generate_images(blocks: List[Dict[str, str]], output_dir: str) -> None:
+    """Add an ``image_path`` to each block, saving images to *output_dir*."""
+    ensure_dir(output_dir)
+    client = OpenAI(api_key=config.OPENAI_API_KEY)
+    for idx, block in enumerate(blocks, 1):
+        try:
+            result = client.images.generate(prompt=block["image_prompt"], model="gpt-image-1")
+            image_b64 = result.data[0].b64_json
+            image_bytes = base64.b64decode(image_b64)
+        except Exception:
+            block["image_path"] = None
+            continue
+
+        filename = f"{idx:03d}_{slugify(block['speaker'])}.png"
+        path = os.path.join(output_dir, filename)
+        with open(path, "wb") as f:
+            f.write(image_bytes)
+        block["image_path"] = path

--- a/main.py
+++ b/main.py
@@ -1,0 +1,34 @@
+"""Entry point for generating audiobook snippets with illustrations."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from split_blocks import split_into_blocks
+from voice_generation import synthesize_speech
+from image_generation import generate_images
+from utils import ensure_dir, load_text, save_json
+
+OUTPUT_DIR = "outputs"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Brothers Karamazov audiobook POC")
+    parser.add_argument("excerpt", help="Path to text excerpt file")
+    args = parser.parse_args()
+
+    ensure_dir(OUTPUT_DIR)
+
+    text = load_text(args.excerpt)
+    blocks = split_into_blocks(text)
+    save_json(blocks, os.path.join(OUTPUT_DIR, "blocks.json"))
+
+    synthesize_speech(blocks, OUTPUT_DIR)
+    generate_images(blocks, OUTPUT_DIR)
+
+    save_json(blocks, os.path.join(OUTPUT_DIR, "blocks_final.json"))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openai
+requests

--- a/split_blocks.py
+++ b/split_blocks.py
@@ -1,0 +1,44 @@
+"""Split an excerpt into blocks with speaker labels and image prompts."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+
+SPEAKER_REGEX = re.compile(
+    r'"[^"\n]+"\s*(?:,\s*)?(?:said|asked|cried)\s+([A-Z][a-z]+)',
+    re.IGNORECASE,
+)
+
+
+def _detect_speaker(block: str) -> str:
+    """Return a speaker name for a block of text."""
+    match = SPEAKER_REGEX.search(block)
+    if match:
+        return match.group(1)
+    return "Narrator"
+
+
+def _image_prompt(speaker: str, text: str) -> str:
+    """Create a lightweight image prompt for *text* spoken by *speaker*."""
+    summary = text.strip().replace("\n", " ")
+    summary = re.sub(r"\s+", " ", summary)[:120]
+    if speaker == "Narrator":
+        return f"Scene: {summary}"
+    return f"{speaker} speaks: {summary}"
+
+
+def split_into_blocks(excerpt: str) -> List[Dict[str, str]]:
+    """Split *excerpt* by double newlines and annotate blocks.
+
+    Returns a list of dictionaries each containing:
+        speaker, text, and image_prompt
+    """
+    raw_blocks = [b.strip() for b in excerpt.split("\n\n") if b.strip()]
+    blocks: List[Dict[str, str]] = []
+    for block in raw_blocks:
+        speaker = _detect_speaker(block)
+        prompt = _image_prompt(speaker, block)
+        blocks.append({"speaker": speaker, "text": block, "image_prompt": prompt})
+    return blocks

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,32 @@
+"""Utility functions for file I/O and helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any
+
+
+def ensure_dir(path: str) -> None:
+    """Ensure that a directory exists."""
+    os.makedirs(path, exist_ok=True)
+
+
+def load_text(path: str) -> str:
+    """Read and return text from *path*."""
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def save_json(data: Any, path: str) -> None:
+    """Serialize *data* as JSON to *path* with UTF-8 encoding."""
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def slugify(value: str) -> str:
+    """Create a filesystem-friendly slug from *value*."""
+    value = value.lower().strip()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return value.strip("-")

--- a/voice_generation.py
+++ b/voice_generation.py
@@ -1,0 +1,52 @@
+"""Generate speech audio for each block using the ElevenLabs API."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List
+
+import requests
+
+import config
+from utils import ensure_dir, slugify
+
+ELEVEN_URL = "https://api.elevenlabs.io/v1/text-to-speech/"
+
+
+def synthesize_speech(blocks: List[Dict[str, str]], output_dir: str) -> None:
+    """Add an ``audio_path`` entry to each block in *blocks*.
+
+    Parameters
+    ----------
+    blocks:
+        List of block dictionaries produced by :func:`split_blocks`.
+    output_dir:
+        Directory where generated audio files will be written.
+    """
+    ensure_dir(output_dir)
+    for idx, block in enumerate(blocks, 1):
+        voice_id = config.ELEVENLABS_VOICE_IDS.get(
+            block["speaker"], config.ELEVENLABS_VOICE_IDS.get("Narrator", "")
+        )
+        if not voice_id:
+            block["audio_path"] = None
+            continue
+
+        payload = {"text": block["text"]}
+        headers = {
+            "xi-api-key": config.ELEVENLABS_API_KEY,
+            "Content-Type": "application/json",
+        }
+
+        try:
+            resp = requests.post(f"{ELEVEN_URL}{voice_id}", json=payload, headers=headers, timeout=30)
+            resp.raise_for_status()
+        except Exception:
+            block["audio_path"] = None
+            continue
+
+        filename = f"{idx:03d}_{slugify(block['speaker'])}.mp3"
+        path = os.path.join(output_dir, filename)
+        with open(path, "wb") as f:
+            f.write(resp.content)
+        block["audio_path"] = path


### PR DESCRIPTION
## Summary
- implement modular pipeline for splitting text, generating audio via ElevenLabs, and creating images via OpenAI
- add utility helpers and entry-point script to orchestrate pipeline
- ignore local config and outputs via `.gitignore`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py split_blocks.py voice_generation.py image_generation.py utils.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689475dd3fc4832d9f1001c885d84139